### PR TITLE
fanout and fanoutSteps recurses even after exhausting input processes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 /buildplan
 /default.nix
 /shell.nix
+.stack-work/

--- a/concurrent-machines.cabal
+++ b/concurrent-machines.cabal
@@ -1,5 +1,5 @@
 name:                concurrent-machines
-version:             0.3.0
+version:             0.3.1
 synopsis:            Concurrent networked stream transducers
 
 description: A simple use-case for this library is to run the stages

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.0
+resolver: lts-8.21
 
 packages:
 - ./.


### PR DESCRIPTION
During fanout and fanoutSteps, the catMaybes removes the processes which are stopped. If all processes are stopped, then fanout and fanoutSteps still enter the Await.. mode, causing it to continue infinitely. 

Handling fanout if no input processes are given, then the machine is stopped. 